### PR TITLE
Edit ignored characters for tokenizer

### DIFF
--- a/config/install/search_api.index.localgov_sitewide_search.yml
+++ b/config/install/search_api.index.localgov_sitewide_search.yml
@@ -114,7 +114,7 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
-    ignored: ._-
+    ignored: ._
     spaces: ''
     overlap_cjk: 1
     minimum_word_size: '3'


### PR DESCRIPTION
Remove the hyphen as an ignored character to allow to fix the warnings when localgov_demo is enabled