### PR TITLE
Adds cache context for s param to fix issue where one user's search string can be displayed to other users.

### DIFF
--- a/src/Plugin/Block/SitewideSearchBlock.php
+++ b/src/Plugin/Block/SitewideSearchBlock.php
@@ -110,6 +110,7 @@ class SitewideSearchBlock extends BlockBase implements ContainerFactoryPluginInt
         $form['#id'] .= '-block';
         $form['s']['#attributes']['placeholder'] = 'Search';
         $form['s']['#required'] = TRUE;
+        $form['#cache']['contexts'] = ['url.query_args:s'];
       }
     }
 


### PR DESCRIPTION
If the search block is built and displayed immediately after a cache clear for a user running a search, their search string is cached and displays in the block on subsequent page loads, for other users.

To recreate the issue:

Load a LocalGov site in two different browsers to simulate two separate users. (eg one chrome window, one safari). Be logged out in both browsers.

Open a terminal and clear the cache with Drush.

In one browser, enter a search term into sitewide search block and submit the form. Once the page loads, hit refresh in the other browser. You'll see the search term you entered in the first browser appear.