### PR TITLE
Feature/test improvements

### DIFF
--- a/modules/localgov_search_db/tests/Functional/SitewideSearchTest.php
+++ b/modules/localgov_search_db/tests/Functional/SitewideSearchTest.php
@@ -19,6 +19,7 @@ class SitewideSearchTest extends SitewideSearchBase {
   protected static $modules = [
     'localgov_search',
     'localgov_search_db',
+    'big_pipe',
   ];
 
 }

--- a/tests/src/Functional/SitewideSearchBase.php
+++ b/tests/src/Functional/SitewideSearchBase.php
@@ -42,6 +42,7 @@ class SitewideSearchBase extends BrowserTestBase {
    */
   protected static $modules = [
     'localgov_search',
+    'big_pipe',
   ];
 
   /**
@@ -151,6 +152,13 @@ class SitewideSearchBase extends BrowserTestBase {
     $this->submitForm(['s' => $body2], 'Apply');
     $this->assertSession()->pageTextContains($title2);
     $this->assertSession()->pageTextContains($summary2);
+
+    // Check caching of block.
+    $this->drupalGet("/search", ['query' => ['s' => $title1]]);
+    $this->assertSession()->pageTextContains($title1);
+    $this->drupalGet("/search", ['query' => ['s' => $title1]]);
+    $this->drupalGet("/search");
+    $this->assertSession()->pageTextNotContains($title1);
   }
 
   /**


### PR DESCRIPTION
Should be three commits - ach. But improvements are:-
 * A change to batch processing that search api tests seem to need so safe to keep here.
 * Moving the index to a method so that search_api_solr can ensure indexing (another PR over there overrides this method) gets rid of the cache clear that was just needed for sorl
 * Some checks on the search block that I wrote trying to reproduce the caching issue, might as well keep them